### PR TITLE
Tooltips

### DIFF
--- a/client/components/Ellipsis.js
+++ b/client/components/Ellipsis.js
@@ -1,0 +1,14 @@
+// external import
+import React from 'react'
+import { css } from 'glamor'
+
+export default props => (
+    <span
+        {...props}
+        {...css({
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+        })}
+    />
+)

--- a/client/components/Portal.js
+++ b/client/components/Portal.js
@@ -22,7 +22,7 @@ export default function Portal({ children, as = 'div', id, ...props }) {
             // if the element doesn't exist
             if (!element) {
                 // create a new element
-                element = document.createElement('div')
+                element = document.createElement(as)
                 // make sure there's only one
                 element.id = portalID
                 // append the element to the DOM

--- a/client/components/Portal.js
+++ b/client/components/Portal.js
@@ -1,0 +1,53 @@
+// external imports
+import React, { useEffect, useState } from 'react'
+import ReactDOM from 'react-dom'
+
+export default function Portal({ children, as = 'div', id, ...props }) {
+    // the id of the portal
+    const portalID = id ? `portal-${id}` : 'portal'
+
+    // a reference to the element we created
+    const [elementRef, setElement] = useState(null)
+
+    // when this component mounts we need to create the element we are
+    // going to use for the portal
+    useEffect(
+        () => {
+            console.log('starting')
+            // look for an element with the designated id
+            let element = document.getElementById(portalID)
+            // the style to apply to the portal container
+            let elementStyle = props.style || {}
+
+            // if the element doesn't exist
+            if (!element) {
+                // create a new element
+                element = document.createElement('div')
+                // make sure there's only one
+                element.id = portalID
+                // append the element to the DOM
+                document.getElementsByTagName('body')[0].appendChild(element)
+            }
+
+            // apply any styles
+            Object.keys(elementStyle).forEach(style => element && element.style.setProperty(style, elementStyle[style]))
+
+            // save the reference to the element
+            setElement(element)
+
+            // when we need to clean up
+            return () => {
+                // if we have an element we created
+                if (element) {
+                    console.log('deleteing portals')
+                    // delete the element from the dom
+                    element.parentNode.removeChild(element)
+                }
+            }
+        },
+        // only run this effect once
+        []
+    )
+
+    return elementRef && ReactDOM.createPortal(children, elementRef)
+}

--- a/client/components/Portal.js
+++ b/client/components/Portal.js
@@ -29,7 +29,12 @@ export default function Portal({ children, as = 'div', id, ...props }) {
             }
 
             // apply any styles
-            Object.keys(elementStyle).forEach(style => element && element.style.setProperty(style, elementStyle[style]))
+            Object.keys(elementStyle).forEach(style => {
+                if (!element) {
+                    return
+                }
+                element.style[style] = elementStyle[style]
+            })
 
             // save the reference to the element
             setElement(element)

--- a/client/components/Portal.js
+++ b/client/components/Portal.js
@@ -13,7 +13,6 @@ export default function Portal({ children, as = 'div', id, ...props }) {
     // going to use for the portal
     useEffect(
         () => {
-            console.log('starting')
             // look for an element with the designated id
             let element = document.getElementById(portalID)
             // the style to apply to the portal container
@@ -39,7 +38,6 @@ export default function Portal({ children, as = 'div', id, ...props }) {
             return () => {
                 // if we have an element we created
                 if (element) {
-                    console.log('deleteing portals')
                     // delete the element from the dom
                     element.parentNode.removeChild(element)
                 }

--- a/client/components/icons/IconInfo.js
+++ b/client/components/icons/IconInfo.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+const SvgInfo = props => (
+    <svg
+        width={24}
+        height={24}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="info_svg__feather info_svg__feather-info"
+        {...props}
+    >
+        <circle cx={12} cy={12} r={10} />
+        <path d="M12 16v-4M12 8h0" />
+    </svg>
+)
+
+export default SvgInfo

--- a/client/components/icons/index.js
+++ b/client/components/icons/index.js
@@ -1,0 +1,1 @@
+export IconInfo from './IconInfo'

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -7,5 +7,6 @@ export Input from './Input'
 export Label from './Label'
 export PrimaryButton from './PrimaryButton'
 export SecondaryButton from './SecondaryButton'
+export Portal from './Portal'
 
 export * from './icons'

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -7,3 +7,5 @@ export Input from './Input'
 export Label from './Label'
 export PrimaryButton from './PrimaryButton'
 export SecondaryButton from './SecondaryButton'
+
+export * from './icons'

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -8,5 +8,6 @@ export Label from './Label'
 export PrimaryButton from './PrimaryButton'
 export SecondaryButton from './SecondaryButton'
 export Portal from './Portal'
+export Ellipsis from './Ellipsis'
 
 export * from './icons'

--- a/client/context/Diagram.js
+++ b/client/context/Diagram.js
@@ -59,6 +59,7 @@ export const DiagramProvider = ({ maxZoom = 2, minZoom = 0.5, zoomStep = 0.1, ch
             }))
         },
         toggleTooltips() {
+            console.log('toggle')
             setState(state => ({
                 ...state,
                 showTooltips: !state.showTooltips,

--- a/client/context/Diagram.js
+++ b/client/context/Diagram.js
@@ -11,8 +11,9 @@ export const DiagramProvider = ({ maxZoom = 2, minZoom = 0.5, zoomStep = 0.1, ch
         showGrid: true,
         gridSize: 50,
         pan: { x: 0, y: 0 },
-        zoomLevel: 1,
         selectedElements: [],
+        showTooltips: false,
+        zoomLevel: 1,
         ...initialState,
     })
 
@@ -45,18 +46,6 @@ export const DiagramProvider = ({ maxZoom = 2, minZoom = 0.5, zoomStep = 0.1, ch
                 zoomLevel,
             }))
         },
-        zoomIn() {
-            setState(state => ({
-                ...state,
-                zoomLevel: Math.min(state.zoomLevel + zoomStep, maxZoom),
-            }))
-        },
-        zoomOut() {
-            setState(state => ({
-                ...state,
-                zoomLevel: Math.max(state.zoomLevel - zoomStep, minZoom),
-            }))
-        },
         selectElements(...elements) {
             setState(state => ({
                 ...state,
@@ -67,6 +56,12 @@ export const DiagramProvider = ({ maxZoom = 2, minZoom = 0.5, zoomStep = 0.1, ch
             setState(state => ({
                 ...state,
                 selectedElements: [],
+            }))
+        },
+        toggleTooltips() {
+            setState(state => ({
+                ...state,
+                showTooltips: !state.showTooltips,
             }))
         },
     }

--- a/client/context/Diagram.js
+++ b/client/context/Diagram.js
@@ -59,7 +59,6 @@ export const DiagramProvider = ({ maxZoom = 2, minZoom = 0.5, zoomStep = 0.1, ch
             }))
         },
         toggleTooltips() {
-            console.log('toggle')
             setState(state => ({
                 ...state,
                 showTooltips: !state.showTooltips,

--- a/client/context/Interface.js
+++ b/client/context/Interface.js
@@ -8,6 +8,10 @@ export const Interface = createContext({
         sidebarWidth: 350,
     },
     colors,
+    shadows: [
+        '0 3px 20px 0 rgba(0,0,0,0.05), 0 2px 4px 0 rgba(0,0,0,0.20), 0 0 1px 0 rgba(0,0,1,0.10)',
+        '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
+    ],
 })
 
 export const InterfaceProvider = Interface.Provider

--- a/client/context/Interface.js
+++ b/client/context/Interface.js
@@ -1,10 +1,13 @@
 // external imports
 import { createContext } from 'react'
+// local imports
+import * as colors from '~/design'
 
 export const Interface = createContext({
     dims: {
         sidebarWidth: 350,
     },
+    colors,
 })
 
 export const InterfaceProvider = Interface.Provider

--- a/client/design.js
+++ b/client/design.js
@@ -3,7 +3,7 @@ export const darkGrey = '#b3aeaa'
 export const lightGrey = '#F1F1F1'
 
 // design
-export const elementOutline = '#616161'
+export const connectorColor = '#616161'
 export const factoryPrimary = '#FF9300'
 
 export const productColor = '#29BDFA'
@@ -11,6 +11,8 @@ export const productFillEmpty = '#D2E5ED'
 
 export const gridStroke = lightGrey
 export const background = '#FAFAFA'
+
+export const iconColor = connectorColor
 
 // selection constants
 export const selectedBorderWidth = 4

--- a/client/interface/Diagram/Grid/index.js
+++ b/client/interface/Diagram/Grid/index.js
@@ -7,7 +7,7 @@ import { range, round } from '~/utils'
 import styles from './styles'
 import { background } from '~/design'
 
-export default ({ style }) => {
+const Grid = ({ style }) => {
     // get the size of the browser
     const browser = useBrowserSize()
     // and the current state of the diagram
@@ -55,3 +55,5 @@ export default ({ style }) => {
         </g>
     )
 }
+
+export default Grid

--- a/client/interface/Diagram/Toolbar.js
+++ b/client/interface/Diagram/Toolbar.js
@@ -8,7 +8,7 @@ import { Diagram } from '~/context'
 
 const Toolbar = props => {
     // grab the diagram info from context
-    const { diagram } = useContext(Diagram)
+    const { toggleTooltips } = useContext(Diagram)
 
     return (
         <div
@@ -25,7 +25,7 @@ const Toolbar = props => {
                     padding: 10,
                     cursor: 'pointer',
                 })}
-                onClick={diagram.toggleTooltips}
+                onClick={toggleTooltips}
             />
         </div>
     )

--- a/client/interface/Diagram/Toolbar.js
+++ b/client/interface/Diagram/Toolbar.js
@@ -1,0 +1,34 @@
+// external imports
+import React, { useContext } from 'react'
+import { css } from 'glamor'
+// local imports
+import { IconInfo } from '~/components'
+import { iconColor } from '~/design'
+import { Diagram } from '~/context'
+
+const Toolbar = props => {
+    // grab the diagram info from context
+    const { diagram } = useContext(Diagram)
+
+    return (
+        <div
+            {...props}
+            {...css({
+                backgroundColor: 'white',
+                boxShadow: '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
+                borderRadius: 3,
+            })}
+        >
+            <IconInfo
+                {...css({
+                    color: iconColor,
+                    padding: 10,
+                    cursor: 'pointer',
+                })}
+                onClick={diagram.toggleTooltips}
+            />
+        </div>
+    )
+}
+
+export default Toolbar

--- a/client/interface/Diagram/Toolbar.js
+++ b/client/interface/Diagram/Toolbar.js
@@ -17,15 +17,15 @@ const Toolbar = props => {
                 backgroundColor: 'white',
                 boxShadow: '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
                 borderRadius: 3,
+                padding: 10,
             })}
+            onClick={toggleTooltips}
         >
             <IconInfo
                 {...css({
                     color: iconColor,
-                    padding: 10,
                     cursor: 'pointer',
                 })}
-                onClick={toggleTooltips}
             />
         </div>
     )

--- a/client/interface/Diagram/Toolbar.js
+++ b/client/interface/Diagram/Toolbar.js
@@ -4,18 +4,19 @@ import { css } from 'glamor'
 // local imports
 import { IconInfo } from '~/components'
 import { iconColor } from '~/design'
-import { Diagram } from '~/context'
+import { Diagram, Interface } from '~/context'
 
 const Toolbar = props => {
     // grab the diagram info from context
     const { toggleTooltips } = useContext(Diagram)
+    const { shadows } = useContext(Interface)
 
     return (
         <div
             {...props}
             {...css({
                 backgroundColor: 'white',
-                boxShadow: '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
+                boxShadow: shadows[1],
                 borderRadius: 3,
                 padding: 10,
             })}

--- a/client/interface/Diagram/Toolbar.js
+++ b/client/interface/Diagram/Toolbar.js
@@ -24,13 +24,13 @@ const Toolbar = props => {
                     position: 'fixed',
                     right: dims.sidebarWidth + 32,
                     bottom: 32,
+                    cursor: 'pointer',
                 })}
                 onClick={toggleTooltips}
             >
                 <IconInfo
                     {...css({
                         color: iconColor,
-                        cursor: 'pointer',
                     })}
                 />
             </div>

--- a/client/interface/Diagram/Toolbar.js
+++ b/client/interface/Diagram/Toolbar.js
@@ -13,7 +13,7 @@ const Toolbar = props => {
 
     return (
         <Portal id="toolbar">
-            <div
+            <button
                 {...props}
                 {...css({
                     backgroundColor: 'white',
@@ -25,6 +25,7 @@ const Toolbar = props => {
                     right: dims.sidebarWidth + 32,
                     bottom: 32,
                     cursor: 'pointer',
+                    border: 'none',
                 })}
                 onClick={toggleTooltips}
             >
@@ -33,7 +34,7 @@ const Toolbar = props => {
                         color: iconColor,
                     })}
                 />
-            </div>
+            </button>
         </Portal>
     )
 }

--- a/client/interface/Diagram/Toolbar.js
+++ b/client/interface/Diagram/Toolbar.js
@@ -2,33 +2,39 @@
 import React, { useContext } from 'react'
 import { css } from 'glamor'
 // local imports
-import { IconInfo } from '~/components'
+import { IconInfo, Portal } from '~/components'
 import { iconColor } from '~/design'
 import { Diagram, Interface } from '~/context'
 
 const Toolbar = props => {
     // grab the diagram info from context
     const { toggleTooltips } = useContext(Diagram)
-    const { shadows } = useContext(Interface)
+    const { shadows, dims } = useContext(Interface)
 
     return (
-        <div
-            {...props}
-            {...css({
-                backgroundColor: 'white',
-                boxShadow: shadows[1],
-                borderRadius: 3,
-                padding: 10,
-            })}
-            onClick={toggleTooltips}
-        >
-            <IconInfo
+        <Portal id="toolbar">
+            <div
+                {...props}
                 {...css({
-                    color: iconColor,
-                    cursor: 'pointer',
+                    backgroundColor: 'white',
+                    boxShadow: shadows[1],
+                    borderRadius: 3,
+                    padding: 10,
+                    zIndex: 100,
+                    position: 'fixed',
+                    right: dims.sidebarWidth + 32,
+                    bottom: 32,
                 })}
-            />
-        </div>
+                onClick={toggleTooltips}
+            >
+                <IconInfo
+                    {...css({
+                        color: iconColor,
+                        cursor: 'pointer',
+                    })}
+                />
+            </div>
+        </Portal>
     )
 }
 

--- a/client/interface/Diagram/index.js
+++ b/client/interface/Diagram/index.js
@@ -49,13 +49,7 @@ const Diagram = () => {
                     </Query>
                 </g>
             </svg>
-            <Toolbar
-                {...css({
-                    position: 'absolute',
-                    right: 30,
-                    bottom: 30,
-                })}
-            />
+            <Toolbar />
         </div>
     )
 }

--- a/client/interface/Diagram/index.js
+++ b/client/interface/Diagram/index.js
@@ -1,27 +1,27 @@
 // external imports
 import { graphql } from 'react-relay'
-import React, { useRef, useEffect, useLayoutEffect, useContext } from 'react'
+import React, { useRef, useEffect, useContext } from 'react'
 import SvgMatrix from 'svg-matrix'
+import { css } from 'glamor'
 // local imports
 import { Query } from '~/components'
 import { Flo } from '~/interface'
-import { Diagram, Interface } from '~/context'
+import { Diagram as DiagramContext } from '~/context'
 import { useKeyPress, useMouseDrag, useEvent } from '~/hooks'
 import Grid from './Grid'
-import SelectionRectangle from './SelectionRectangle'
-import * as styles from './styles'
+import Toolbar from './Toolbar'
 
-export default () => {
+const Diagram = () => {
     // we need a ref to track interactions with the diagram
-    const elementRef = useRef(null)
+    const diagramElement = useRef(null)
 
     // enable the mousewheel zoom behavior
-    // useZoomBehavior(elementRef)
+    // useZoomBehavior(diagram)
     // and the drag behavior
-    useDragBehavior(elementRef)
+    useDragBehavior(diagramElement)
 
     // grab the info and actions we need from the diagram
-    const { diagram } = useContext(Diagram)
+    const { diagram } = useContext(DiagramContext)
 
     // compute the transform string for the diagram
     const { transformString } = SvgMatrix()
@@ -29,16 +29,34 @@ export default () => {
         .scale(diagram.zoomLevel)
 
     return (
-        <svg style={styles.container} ref={elementRef}>
-            <g transform={transformString}>
-                <Grid />
+        // we want to wrap the diagram in a div so we can easily position the tools over it
+        <div
+            {...css({
+                display: 'flex',
+                flexGrow: 1,
+                cursor: 'default',
+                zIndex: 1,
+                position: 'relative',
+            })}
+        >
+            <svg {...css({ width: '100%', height: '100%' })} ref={diagramElement}>
+                <g transform={transformString}>
+                    <Grid />
 
-                {/* make sure the diagram sits above the grid */}
-                <Query query={floQuery} variables={{ id: 'RmxvOjA=' }} loadingState={null}>
-                    {({ node }) => <Flo flo={node} />}
-                </Query>
-            </g>
-        </svg>
+                    {/* make sure the diagram sits above the grid */}
+                    <Query query={floQuery} variables={{ id: 'RmxvOjA=' }} loadingState={null}>
+                        {({ node }) => <Flo flo={node} />}
+                    </Query>
+                </g>
+            </svg>
+            <Toolbar
+                {...css({
+                    position: 'absolute',
+                    right: 30,
+                    bottom: 30,
+                })}
+            />
+        </div>
     )
 }
 
@@ -54,7 +72,7 @@ const floQuery = graphql`
 `
 
 const useDragBehavior = elementRef => {
-    const { pan } = useContext(Diagram)
+    const { pan } = useContext(DiagramContext)
     // we care if the space bar is pressed
     const spacePressed = useKeyPress(' ')
 
@@ -102,3 +120,5 @@ const useZoomBehavior = elementRef => {
         }
     })
 }
+
+export default Diagram

--- a/client/interface/Diagram/styles.js
+++ b/client/interface/Diagram/styles.js
@@ -1,8 +1,0 @@
-import { background } from '~/design'
-
-export const container = {
-    display: 'flex',
-    flexGrow: 1,
-    cursor: 'default',
-    zIndex: 1,
-}

--- a/client/interface/Flo/Factory.js
+++ b/client/interface/Flo/Factory.js
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 import { createFragmentContainer, graphql } from 'react-relay'
 // local imports
 import {
-    elementOutline,
+    connectorColor,
     factoryPrimary,
     selectedBorderWidth,
     selectedBorderGap,

--- a/client/interface/Flo/Lines.js
+++ b/client/interface/Flo/Lines.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import { createFragmentContainer, graphql } from 'react-relay'
 // local imports
-import { elementOutline } from '~/design'
+import { connectorColor } from '~/design'
 
 // the primary length for the squares that define the in and out point
 const squareLength = 3
@@ -27,7 +27,7 @@ const Lines = ({ flo }) => (
                     // only show the input rectangle if there is more than one product
                     {factory.inputs.length !== 1 && (
                         <rect
-                            fill={elementOutline}
+                            fill={connectorColor}
                             x={leftSquareLocation.x - squareLength}
                             y={leftSquareLocation.y - squareLength}
                             width={2 * squareLength}
@@ -37,7 +37,7 @@ const Lines = ({ flo }) => (
                     // only show the output rectangle if there is more than one result
                     {factory.outputs.length !== 1 && (
                         <rect
-                            fill={elementOutline}
+                            fill={connectorColor}
                             x={rightSquareLocation.x - squareLength}
                             y={rightSquareLocation.y - squareLength}
                             width={2 * squareLength}
@@ -46,7 +46,7 @@ const Lines = ({ flo }) => (
                     )}
                     // there is a line going from one square to the other
                     <line
-                        stroke={elementOutline}
+                        stroke={connectorColor}
                         strokeWidth={1}
                         x1={factory.position.x + armLength}
                         y1={factory.position.y}
@@ -61,7 +61,7 @@ const Lines = ({ flo }) => (
                                 y1={leftSquareLocation.y}
                                 x2={leftSquareLocation.x}
                                 y2={binding.product.position.y}
-                                stroke={elementOutline}
+                                stroke={connectorColor}
                                 strokeWidth={1}
                             />
                             <line
@@ -69,7 +69,7 @@ const Lines = ({ flo }) => (
                                 y1={binding.product.position.y}
                                 x2={binding.product.position.x}
                                 y2={binding.product.position.y}
-                                stroke={elementOutline}
+                                stroke={connectorColor}
                                 strokeWidth={1}
                             />
                         </React.Fragment>
@@ -82,7 +82,7 @@ const Lines = ({ flo }) => (
                                 y1={rightSquareLocation.y}
                                 x2={rightSquareLocation.x}
                                 y2={result.product.position.y}
-                                stroke={elementOutline}
+                                stroke={connectorColor}
                                 strokeWidth={1}
                             />
                             <line
@@ -90,7 +90,7 @@ const Lines = ({ flo }) => (
                                 y1={result.product.position.y}
                                 x2={result.product.position.x}
                                 y2={result.product.position.y}
-                                stroke={elementOutline}
+                                stroke={connectorColor}
                                 strokeWidth={1}
                             />
                         </React.Fragment>

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -13,54 +13,6 @@ import { Radius } from '~/components/Product'
 // the radius of the inner circle
 const gutter = 15
 
-const Tooltip = ({ product, ...props }) => {
-    // we need to know the current translation on the diagram to follow it
-    const { diagram } = useContext(Diagram)
-
-    // we need to render the portal outside of the immediate dom tree so we can render HTML
-    // without the annoyance of embedding the element in a foreignObject (and have to have a definite width)
-    return (
-        <Portal id={`tooltip-${product.id}`}>
-            <div
-                {...css({
-                    position: 'fixed',
-                    zIndex: 10,
-                    transform: 'translate(-50%, -50%)',
-                    height: 50,
-                    backgroundColor: 'white',
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: 'flex-start',
-                    alignItems: 'center',
-                    padding: 12,
-                    borderRadius: 3,
-                    boxShadow: '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
-                })}
-                style={{
-                    top: product.position.y - 50 + diagram.pan.y,
-                    left: product.position.x + diagram.pan.x,
-                }}
-            >
-                <ProductCircle
-                    progress={1}
-                    {...css({
-                        marginRight: 8,
-                    })}
-                />
-                <div
-                    {...css({
-                        display: 'flex',
-                        flexDirection: 'column',
-                    })}
-                >
-                    <div>{product.name}</div>
-                    <div>{product.description}</div>
-                </div>
-            </div>
-        </Portal>
-    )
-}
-
 const Product = ({ product }) => {
     // grab the diagram selected state
     const { diagram } = useContext(Diagram)
@@ -180,6 +132,54 @@ const Product = ({ product }) => {
             </Draggable>
             {diagram.showTooltips && <Tooltip product={product} x={product.position.x} y={product.position.y - 50} />}
         </>
+    )
+}
+
+const Tooltip = ({ product, ...props }) => {
+    // we need to know the current translation on the diagram to follow it
+    const { diagram } = useContext(Diagram)
+
+    // we need to render the portal outside of the immediate dom tree so we can render HTML
+    // without the annoyance of embedding the element in a foreignObject (and have to have a definite width)
+    return (
+        <Portal id={`tooltip-${product.id}`}>
+            <div
+                {...css({
+                    position: 'fixed',
+                    zIndex: 10,
+                    transform: 'translate(-50%, -50%)',
+                    height: 50,
+                    backgroundColor: 'white',
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'flex-start',
+                    alignItems: 'center',
+                    padding: 12,
+                    borderRadius: 3,
+                    boxShadow: '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
+                })}
+                style={{
+                    top: product.position.y - 50 + diagram.pan.y,
+                    left: product.position.x + diagram.pan.x,
+                }}
+            >
+                <ProductCircle
+                    progress={product.progress}
+                    {...css({
+                        marginRight: 8,
+                    })}
+                />
+                <div
+                    {...css({
+                        display: 'flex',
+                        flexDirection: 'column',
+                    })}
+                >
+                    <div>{product.name}</div>
+                    <div>{product.description}</div>
+                </div>
+            </div>
+        </Portal>
     )
 }
 

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 import { graphql, createFragmentContainer } from 'react-relay'
 import { css } from 'glamor'
 // local imports
-import { Arc, Draggable, Product as ProductCircle, Portal } from '~/components'
+import { Arc, Draggable, Product as ProductCircle, Portal, Ellipsis } from '~/components'
 import { background, connectorColor, productSelectedBorder, selectedBorderWidth, selectedBorderGap } from '~/design'
 import { useSubscription, useBrowserSize } from '~/hooks'
 import { Diagram, Environment, Interface } from '~/context'
@@ -158,6 +158,7 @@ const Tooltip = ({ product, ...props }) => {
                     padding: 12,
                     borderRadius: 3,
                     boxShadow: shadows[0],
+                    width: 250,
                 })}
                 style={{
                     top: product.position.y - 50 + diagram.pan.y,
@@ -174,16 +175,18 @@ const Tooltip = ({ product, ...props }) => {
                     {...css({
                         display: 'flex',
                         flexDirection: 'column',
+                        flexGrow: 1,
+                        width: 10,
                     })}
                 >
-                    <div
+                    <Ellipsis
                         {...css({
                             fontSize: 14,
                         })}
                     >
                         {product.name}
-                    </div>
-                    <div
+                    </Ellipsis>
+                    <Ellipsis
                         {...css({
                             color: colors.darkGrey,
                             fontSize: 12,
@@ -191,7 +194,7 @@ const Tooltip = ({ product, ...props }) => {
                         })}
                     >
                         {product.description}
-                    </div>
+                    </Ellipsis>
                 </div>
             </div>
         </Portal>

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -12,13 +12,29 @@ import { Radius } from '~/components/Product'
 // the radius of the inner circle
 const gutter = 15
 
-const Tooltip = ({ product, ...props }) => {
-    return (
-        <Portal id={`tooltip-${product.id}`}>
-            <div>hello</div>
-        </Portal>
-    )
-}
+const Tooltip = ({ product, ...props }) => (
+    <Portal
+        id={`tooltip-${product.id}`}
+        style={{
+            position: 'fixed',
+            left: product.position.x,
+            top: product.position.y - 40,
+            zIndex: 10,
+            transform: 'translate(-50%, -50%)',
+            height: 75,
+            width: 300,
+            backgroundColor: 'white',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'flex-start',
+            alignItems: 'center',
+            padding: 12,
+        }}
+    >
+        <ProductCircle progress={1} />
+        <div>hello</div>
+    </Portal>
+)
 
 const Product = ({ product }) => {
     // grab the diagram selected state

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -1,40 +1,65 @@
 // external imports
 import React, { useContext } from 'react'
 import { graphql, createFragmentContainer } from 'react-relay'
+import { css } from 'glamor'
 // local imports
 import { Arc, Draggable, Product as ProductCircle, Portal } from '~/components'
 import { background, connectorColor, productSelectedBorder, selectedBorderWidth, selectedBorderGap } from '~/design'
-import { useSubscription } from '~/hooks'
-import { Diagram, Environment } from '~/context'
+import { useSubscription, useBrowserSize } from '~/hooks'
+import { Diagram, Environment, Interface } from '~/context'
 import { mutate } from '~/utils'
 import { Radius } from '~/components/Product'
 
 // the radius of the inner circle
 const gutter = 15
 
-const Tooltip = ({ product, ...props }) => (
-    <Portal
-        id={`tooltip-${product.id}`}
-        style={{
-            position: 'fixed',
-            left: product.position.x,
-            top: product.position.y - 40,
-            zIndex: 10,
-            transform: 'translate(-50%, -50%)',
-            height: 75,
-            width: 300,
-            backgroundColor: 'white',
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'flex-start',
-            alignItems: 'center',
-            padding: 12,
-        }}
-    >
-        <ProductCircle progress={1} />
-        <div>hello</div>
-    </Portal>
-)
+const Tooltip = ({ product, ...props }) => {
+    // we need to know the current translation on the diagram to follow it
+    const { diagram } = useContext(Diagram)
+
+    // we need to render the portal outside of the immediate dom tree so we can render HTML
+    // without the annoyance of embedding the element in a foreignObject (and have to have a definite width)
+    return (
+        <Portal id={`tooltip-${product.id}`}>
+            <div
+                {...css({
+                    position: 'fixed',
+                    zIndex: 10,
+                    transform: 'translate(-50%, -50%)',
+                    height: 50,
+                    backgroundColor: 'white',
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'flex-start',
+                    alignItems: 'center',
+                    padding: 12,
+                    borderRadius: 3,
+                    boxShadow: '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
+                })}
+                style={{
+                    top: product.position.y - 50 + diagram.pan.y,
+                    left: product.position.x + diagram.pan.x,
+                }}
+            >
+                <ProductCircle
+                    progress={1}
+                    {...css({
+                        marginRight: 8,
+                    })}
+                />
+                <div
+                    {...css({
+                        display: 'flex',
+                        flexDirection: 'column',
+                    })}
+                >
+                    <div>{product.name}</div>
+                    <div>{product.description}</div>
+                </div>
+            </div>
+        </Portal>
+    )
+}
 
 const Product = ({ product }) => {
     // grab the diagram selected state
@@ -164,6 +189,8 @@ export default createFragmentContainer(
         fragment Product_product on Product {
             id
             progress
+            name
+            description
             position {
                 x
                 y

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -156,7 +156,8 @@ const Tooltip = ({ product, ...props }) => {
                     alignItems: 'center',
                     padding: 12,
                     borderRadius: 3,
-                    boxShadow: '0 3px 6px rgba(0,0,0,0.19), 0 3px 6px rgba(0,0,0,0.23)',
+                    boxShadow:
+                        '0 3px 20px 0 rgba(0,0,0,0.05), 0 2px 4px 0 rgba(0,0,0,0.20), 0 0 1px 0 rgba(0,0,1,0.10)',
                 })}
                 style={{
                     top: product.position.y - 50 + diagram.pan.y,

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -138,6 +138,7 @@ const Product = ({ product }) => {
 const Tooltip = ({ product, ...props }) => {
     // we need to know the current translation on the diagram to follow it
     const { diagram } = useContext(Diagram)
+    const { colors } = useContext(Interface)
 
     // we need to render the portal outside of the immediate dom tree so we can render HTML
     // without the annoyance of embedding the element in a foreignObject (and have to have a definite width)
@@ -176,8 +177,22 @@ const Tooltip = ({ product, ...props }) => {
                         flexDirection: 'column',
                     })}
                 >
-                    <div>{product.name}</div>
-                    <div>{product.description}</div>
+                    <div
+                        {...css({
+                            fontSize: 14,
+                        })}
+                    >
+                        {product.name}
+                    </div>
+                    <div
+                        {...css({
+                            color: colors.darkGrey,
+                            fontSize: 12,
+                            lineHeight: 1,
+                        })}
+                    >
+                        {product.description}
+                    </div>
                 </div>
             </div>
         </Portal>

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -138,7 +138,7 @@ const Product = ({ product }) => {
 const Tooltip = ({ product, ...props }) => {
     // we need to know the current translation on the diagram to follow it
     const { diagram } = useContext(Diagram)
-    const { colors } = useContext(Interface)
+    const { colors, shadows } = useContext(Interface)
 
     // we need to render the portal outside of the immediate dom tree so we can render HTML
     // without the annoyance of embedding the element in a foreignObject (and have to have a definite width)
@@ -157,8 +157,7 @@ const Tooltip = ({ product, ...props }) => {
                     alignItems: 'center',
                     padding: 12,
                     borderRadius: 3,
-                    boxShadow:
-                        '0 3px 20px 0 rgba(0,0,0,0.05), 0 2px 4px 0 rgba(0,0,0,0.20), 0 0 1px 0 rgba(0,0,1,0.10)',
+                    boxShadow: shadows[0],
                 })}
                 style={{
                     top: product.position.y - 50 + diagram.pan.y,

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -2,7 +2,7 @@
 import React, { useContext } from 'react'
 import { graphql, createFragmentContainer } from 'react-relay'
 // local imports
-import { Arc, Draggable, Product as ProductCircle } from '~/components'
+import { Arc, Draggable, Product as ProductCircle, Portal } from '~/components'
 import { background, connectorColor, productSelectedBorder, selectedBorderWidth, selectedBorderGap } from '~/design'
 import { useSubscription } from '~/hooks'
 import { Diagram, Environment } from '~/context'
@@ -11,6 +11,14 @@ import { Radius } from '~/components/Product'
 
 // the radius of the inner circle
 const gutter = 15
+
+const Tooltip = ({ product, ...props }) => {
+    return (
+        <Portal id={`tooltip-${product.id}`}>
+            <div>hello</div>
+        </Portal>
+    )
+}
 
 const Product = ({ product }) => {
     // grab the diagram selected state
@@ -38,91 +46,99 @@ const Product = ({ product }) => {
     )
 
     return (
-        <Draggable
-            id={product.id}
-            origin={product.position}
-            onMove={position =>
-                mutate({
-                    environment,
-                    query: graphql`
-                        mutation ProductMoveProductMutation($product: ID!, $x: Int!, $y: Int!) {
-                            moveProduct(product: $product, x: $x, y: $y) {
-                                product {
-                                    id
-                                    position {
-                                        x
-                                        y
+        <>
+            <Draggable
+                id={product.id}
+                origin={product.position}
+                onMove={position =>
+                    mutate({
+                        environment,
+                        query: graphql`
+                            mutation ProductMoveProductMutation($product: ID!, $x: Int!, $y: Int!) {
+                                moveProduct(product: $product, x: $x, y: $y) {
+                                    product {
+                                        id
+                                        position {
+                                            x
+                                            y
+                                        }
                                     }
                                 }
                             }
-                        }
-                    `,
-                    variables: { product: product.id, ...position },
-                    optimisticResponse: {
-                        moveProduct: {
-                            product: {
-                                id: product.id,
-                                position,
+                        `,
+                        variables: { product: product.id, ...position },
+                        optimisticResponse: {
+                            moveProduct: {
+                                product: {
+                                    id: product.id,
+                                    position,
+                                },
                             },
                         },
-                    },
-                })
-            }
-        >
-            <>
-                // render the outer circle
-                {do {
-                    // render a full circle if there are both a source and at least one binding
-                    if (product.source && product.bindings.length > 0) {
-                        ;<circle fill={connectorColor} cx={product.position.x} cy={product.position.y} r={gutter + 1} />
-                    }
-                    // if there is no source, then there is only bindings
-                    else if (product.source) {
-                        // so render the arc that leaves the gap on the right
-                        ;<Arc
-                            r={gutter + 1}
-                            x={product.position.x}
-                            y={product.position.y}
-                            theta1={-230}
-                            theta2={40}
-                            stroke={connectorColor}
-                        />
-                    }
-                    // there are only bindings
-                    else if (product.bindings.length > 0) {
-                        // so render the arc tha leaves the gap on the left
-                        ;<Arc
-                            r={gutter + 1}
-                            x={product.position.x}
-                            y={product.position.y}
-                            theta1={-40}
-                            theta2={230}
-                            stroke={connectorColor}
-                        />
-                    }
-                }}
-                // render some space between the fillter and the border
-                <circle fill={background} cx={product.position.x} cy={product.position.y} r={gutter} />
-                // if this element is selected we should show a visual indicator
-                {diagram.selectedElements.includes(product.id) && (
-                    <>
-                        <circle
-                            fill={productSelectedBorder}
-                            cx={product.position.x}
-                            cy={product.position.y}
-                            r={Radius + selectedBorderWidth + selectedBorderGap}
-                        />
-                        <circle
-                            fill={background}
-                            cx={product.position.x}
-                            cy={product.position.y}
-                            r={Radius + selectedBorderGap}
-                        />
-                    </>
-                )}
-                <ProductCircle x={product.position.x} y={product.position.y} progress={product.progress} />
-            </>
-        </Draggable>
+                    })
+                }
+            >
+                <>
+                    // render the outer circle
+                    {do {
+                        // render a full circle if there are both a source and at least one binding
+                        if (product.source && product.bindings.length > 0) {
+                            ;<circle
+                                fill={connectorColor}
+                                cx={product.position.x}
+                                cy={product.position.y}
+                                r={gutter + 1}
+                            />
+                        }
+                        // if there is no source, then there is only bindings
+                        else if (product.source) {
+                            // so render the arc that leaves the gap on the right
+                            ;<Arc
+                                r={gutter + 1}
+                                x={product.position.x}
+                                y={product.position.y}
+                                theta1={-230}
+                                theta2={40}
+                                stroke={connectorColor}
+                            />
+                        }
+                        // there are only bindings
+                        else if (product.bindings.length > 0) {
+                            // so render the arc tha leaves the gap on the left
+                            ;<Arc
+                                r={gutter + 1}
+                                x={product.position.x}
+                                y={product.position.y}
+                                theta1={-40}
+                                theta2={230}
+                                stroke={connectorColor}
+                            />
+                        }
+                    }}
+                    // render some space between the fillter and the border
+                    <circle fill={background} cx={product.position.x} cy={product.position.y} r={gutter} />
+                    // if this element is selected we should show a visual indicator
+                    {diagram.selectedElements.includes(product.id) && (
+                        <>
+                            <circle
+                                fill={productSelectedBorder}
+                                cx={product.position.x}
+                                cy={product.position.y}
+                                r={Radius + selectedBorderWidth + selectedBorderGap}
+                            />
+                            <circle
+                                fill={background}
+                                cx={product.position.x}
+                                cy={product.position.y}
+                                r={Radius + selectedBorderGap}
+                            />
+                        </>
+                    )}
+                    <ProductCircle x={product.position.x} y={product.position.y} progress={product.progress} />
+                </>
+            </Draggable>
+            {diagram.showTooltips && <Tooltip product={product} x={product.position.x} y={product.position.y - 50} />}
+        </>
     )
 }
 

--- a/client/interface/Flo/Product.js
+++ b/client/interface/Flo/Product.js
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 import { graphql, createFragmentContainer } from 'react-relay'
 // local imports
 import { Arc, Draggable, Product as ProductCircle } from '~/components'
-import { background, elementOutline, productSelectedBorder, selectedBorderWidth, selectedBorderGap } from '~/design'
+import { background, connectorColor, productSelectedBorder, selectedBorderWidth, selectedBorderGap } from '~/design'
 import { useSubscription } from '~/hooks'
 import { Diagram, Environment } from '~/context'
 import { mutate } from '~/utils'
@@ -14,7 +14,7 @@ const gutter = 15
 
 const Product = ({ product }) => {
     // grab the diagram selected state
-    const { diagram, selectElements } = useContext(Diagram)
+    const { diagram } = useContext(Diagram)
     const environment = useContext(Environment)
 
     // make sure we update this component when the product moves
@@ -74,7 +74,7 @@ const Product = ({ product }) => {
                 {do {
                     // render a full circle if there are both a source and at least one binding
                     if (product.source && product.bindings.length > 0) {
-                        ;<circle fill={elementOutline} cx={product.position.x} cy={product.position.y} r={gutter + 1} />
+                        ;<circle fill={connectorColor} cx={product.position.x} cy={product.position.y} r={gutter + 1} />
                     }
                     // if there is no source, then there is only bindings
                     else if (product.source) {
@@ -85,7 +85,7 @@ const Product = ({ product }) => {
                             y={product.position.y}
                             theta1={-230}
                             theta2={40}
-                            stroke={elementOutline}
+                            stroke={connectorColor}
                         />
                     }
                     // there are only bindings
@@ -97,7 +97,7 @@ const Product = ({ product }) => {
                             y={product.position.y}
                             theta1={-40}
                             theta2={230}
-                            stroke={elementOutline}
+                            stroke={connectorColor}
                         />
                     }
                 }}

--- a/client/interface/Sidebar/index.js
+++ b/client/interface/Sidebar/index.js
@@ -14,7 +14,13 @@ export default () => {
     const { dims } = useContext(Interface)
 
     return (
-        <div {...css({ ...styles.container, width: dims.sidebarWidth, borderLeft: `solid 1px ${lightGrey}` })}>
+        <div
+            {...css({
+                ...styles.container,
+                width: dims.sidebarWidth,
+                borderLeft: `solid 1px ${lightGrey}`,
+            })}
+        >
             {diagram.selectedElements.length === 0 ? <NoSelection /> : <WithSelection />}
         </div>
     )

--- a/client/interface/Sidebar/index.js
+++ b/client/interface/Sidebar/index.js
@@ -19,6 +19,7 @@ export default () => {
                 ...styles.container,
                 width: dims.sidebarWidth,
                 borderLeft: `solid 1px ${lightGrey}`,
+                zIndex: 100,
             })}
         >
             {diagram.selectedElements.length === 0 ? <NoSelection /> : <WithSelection />}

--- a/client/interface/Sidebar/index.js
+++ b/client/interface/Sidebar/index.js
@@ -6,6 +6,7 @@ import * as styles from './styles'
 import { Diagram, Interface } from '~/context'
 import NoSelection from './NoSelection'
 import WithSelection from './WithSelection'
+import { lightGrey } from '~/design'
 
 export default () => {
     // grab the context values we care about
@@ -13,7 +14,7 @@ export default () => {
     const { dims } = useContext(Interface)
 
     return (
-        <div {...css({ ...styles.container, width: dims.sidebarWidth })}>
+        <div {...css({ ...styles.container, width: dims.sidebarWidth, borderLeft: `solid 1px ${lightGrey}` })}>
             {diagram.selectedElements.length === 0 ? <NoSelection /> : <WithSelection />}
         </div>
     )

--- a/client/reset.css
+++ b/client/reset.css
@@ -181,3 +181,7 @@ pre {
     font-weight: 400;
     line-height: 18.5714px;
 }
+
+* {
+    box-sizing: border-box;
+}


### PR DESCRIPTION
This PR adds a button to the bottom right of the diagram area that shows a simple tooltip over each product when clicked. The tooltips can be toggled off by clicking the button again. 

@aivazis I'm not sure if you want me to polish the design off now or move onto dragging factories from the sidebar. If you want me to move onto adding factories to a flo, I can add an issue with the improvements I want to make. Some things I'd like to do are:
  * Add different visual states to the toggle (mousedown and active)
  * Handle overflow in the tooltip with an ellipsis or something similar